### PR TITLE
Fix memory leak with recorder

### DIFF
--- a/src/ScreenRecorder.tsx
+++ b/src/ScreenRecorder.tsx
@@ -92,6 +92,7 @@ const ScreenRecorder: React.FC = () => {
     if (recorder) {
       recorder.stop();
       setIsRecording(false);
+      setRecorder(null);
     }
   };
 


### PR DESCRIPTION
# Set `recorder` to null after stopping recording

- [x] Fix memory leak with the `recorder` not being set to null when the recording is stopped.